### PR TITLE
two fixes for generating and creating capnp objects for output

### DIFF
--- a/CapnProto.net.Schema/CSharpStructWriter.cs
+++ b/CapnProto.net.Schema/CSharpStructWriter.cs
@@ -945,7 +945,9 @@ namespace CapnProto
                 case Value.Unions.uint32: if (defaultValue.uint32 != 0) Write(" ^ ").WriteLiteral(defaultValue.uint32); break;
                 case Value.Unions.int64: if (defaultValue.int64 != 0) Write(" ^ ").WriteLiteral(defaultValue.int64); break;
                 case Value.Unions.uint64: if (defaultValue.uint64 != 0) Write(" ^ ").WriteLiteral(defaultValue.uint64); break;
-                default:
+				case Value.Unions.float32: if (defaultValue.float32 != 0) Write(" ^ ").WriteLiteral(defaultValue.float32); break;
+				case Value.Unions.float64: if (defaultValue.float64 != 0) Write(" ^ ").WriteLiteral(defaultValue.float64); break;
+				default:
                     throw new NotSupportedException("Default value not supported for: " + defaultValue.Union);
             }
             return this;

--- a/CapnProto.net/Pointer.cs
+++ b/CapnProto.net/Pointer.cs
@@ -938,7 +938,9 @@ namespace CapnProto
                 }
                 else if (segment.TryAllocate(words, out start))
                 { // in-segment pointer
-                    return new Pointer(segment, (uint)(start << 3) | (type & 7), dataAndWords, aux);
+					// write # of words and pointers into segment
+					if (start > 0) segment[start - 1] = (ulong)dataAndWords << 32;
+					return new Pointer(segment, (uint)(start << 3) | (type & 7), dataAndWords, aux);
                 }
                 else
                 {   // far pointer; will need the data and a header; ideally, in the same block


### PR DESCRIPTION
I needed to generate and write capnp objects, and the process of getting it to work led to the two fixes committed here.

The second commit to Pointer.cs needs review. Comparing the message byte output of capnproto .NET to C++ showed that the "number of words" and "number of pointers" values were not being written into the segment, so the message could not be read back. The commit to Pointer.cs writes those values into the correct place in the case of a single allocation for a single struct message. However, I don't know enough about capnproto internals to know what else belongs in the lower 4 bytes of that data word, or if there are other cases to handle there. Also, assigning to "start - 1" seems brittle, although that is the right place in the segment.